### PR TITLE
AE-26000 | Recoverability Feature

### DIFF
--- a/aboutlibraries-core/src/commonMain/kotlin/com/mikepenz/aboutlibraries/Libs.kt
+++ b/aboutlibraries-core/src/commonMain/kotlin/com/mikepenz/aboutlibraries/Libs.kt
@@ -17,6 +17,7 @@ data class Libs constructor(
      */
     class Builder {
         private var _stringData: String? = null
+        private var recoverable: Boolean = false
 
         /**
          * Provide the generated library data as [String]
@@ -27,12 +28,22 @@ data class Libs constructor(
         }
 
         /**
+         * Don't crash on missing library data. Instead fill in:
+         * [Library.name] = use [Library.uniqueId]
+         * [Library.developers] = use [emptyList]
+         */
+        fun recoverableMissingData(recoverable: Boolean): Builder {
+            this.recoverable = recoverable
+            return this
+        }
+
+        /**
          * Build the [Libs] instance with the applied configuration.
          */
         fun build(): Libs {
             val data = _stringData
             val (libraries, licenses) = if (data != null) {
-                parseData(data)
+                parseData(data, recoverable)
             } else {
                 throw IllegalStateException(
                     """

--- a/aboutlibraries-core/src/commonMain/kotlin/com/mikepenz/aboutlibraries/util/Parser.kt
+++ b/aboutlibraries-core/src/commonMain/kotlin/com/mikepenz/aboutlibraries/util/Parser.kt
@@ -3,7 +3,7 @@ package com.mikepenz.aboutlibraries.util
 import com.mikepenz.aboutlibraries.entity.Library
 import com.mikepenz.aboutlibraries.entity.License
 
-expect fun parseData(json: String): Result
+expect fun parseData(json: String, recoverable: Boolean = false): Result
 
 class Result(
     val libraries: List<Library>,

--- a/aboutlibraries/src/main/java/com/mikepenz/aboutlibraries/ui/LibsSupportFragment.kt
+++ b/aboutlibraries/src/main/java/com/mikepenz/aboutlibraries/ui/LibsSupportFragment.kt
@@ -29,7 +29,6 @@ import com.mikepenz.fastadapter.FastAdapter
 import com.mikepenz.fastadapter.GenericItem
 import com.mikepenz.fastadapter.adapters.ItemAdapter
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -52,7 +51,9 @@ open class LibsSupportFragment : Fragment(), Filterable {
                 Log.i("AboutLibraries", "Fallback to default configuration, due to missing argument")
                 LibsBuilder()
             },
-            Libs.Builder().withContext(requireContext())
+            Libs.Builder()
+                .withContext(requireContext())
+                .recoverableMissingData(recoverable = true)
         )
     }
 

--- a/app/src/main/java/com/mikepenz/aboutlibraries/sample/FragmentActivity.kt
+++ b/app/src/main/java/com/mikepenz/aboutlibraries/sample/FragmentActivity.kt
@@ -170,7 +170,10 @@ class FragmentActivity : AppCompatActivity() {
         fragmentManager.beginTransaction().replace(R.id.frame_container, fragment).commit()
 
         // Showcase to use the library meta information without the UI module
-        Libs.Builder().withContext(this).build().libraries
+        Libs.Builder()
+            .withContext(this)
+            .recoverableMissingData(recoverable = true)
+            .build().libraries
             .forEach {
                 Log.d("AboutLibraries", it.name)
             }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.mikepenz
-VERSION_NAME=10.6.3
-VERSION_CODE=100603
+VERSION_NAME=10.6.4
+VERSION_CODE=100604
 
 POM_URL=https://github.com/mikepenz/AboutLibraries
 POM_SCM_URL=https://github.com/mikepenz/AboutLibraries


### PR DESCRIPTION
## Changes
- Created a new flag for the library builder.
  - Created defaults when the flag is on: 
    - name - replaced by `"uniqueId"` which represents the package name. 
    - developers - replaced by an `emptyList()` if none exist.